### PR TITLE
docs(readme): update clone URL to smartqr-org and fix Mobile node flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ React and Vue bindings will be available in future releases.
 Clone the repo:
 
 ```bash
-git clone https://github.com/smartqr/smart-qr.git
+git clone https://github.com/smartqr-org/smart-qr.git
 cd smart-qr
 ```
 


### PR DESCRIPTION
### Description
Update documentation to reflect the new organization and correct the core flowchart:
- **Global README**: set clone URL to `https://github.com/smartqr-org/smart-qr.git`.
- **Core README**: connect the **Mobile** node to the deep link + timeout path in the Mermaid diagram.

### Changes
- `README.md`: replace placeholder/old clone URL with the smartqr-org URL.
- `packages/core/README.md`: add `K --> J` edge in the flowchart.

### Context
Ensures contributors can clone the repo directly from the new organization and that the flow diagram renders logically on GitHub.

### QA Checklist
- [x] Mermaid diagram renders without syntax errors.
- [x] Clone instructions work: `git clone https://github.com/smartqr-org/smart-qr.git`.
- [x] No runtime/code changes; docs only.

### Related issues
Closes #<issue_number_here>
